### PR TITLE
Add Makefile and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore environment files copied from examples
+**/.env
+*.env
+*/.env
+
+# Ignore editor and Python artifacts
+__pycache__/
+*.pyc
+
+# Misc
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SERVICES=Iris Shuffle misp suricata-zeek wazuh-docker-main
+
+.PHONY: init up down config
+
+init:
+	@for d in $(SERVICES); do \
+		cp $$d/.env.example $$d/.env; \
+	done
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+config:
+	docker compose config

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ This repository contains Docker compose environments for multiple services. Each
 - suricata-zeek
 - wazuh-docker-main
 
-You can now orchestrate everything from the repository root. After copying every `.env.example` to `.env` within each service directory, run:
+You can now orchestrate everything from the repository root. The provided Makefile automates the setup:
 
 ```bash
-docker compose up -d
+make init   # copy every .env.example to .env
+make up     # start all containers
 ```
 
-This uses the root `docker-compose.yml` which extends the individual service files. You may also run `docker compose config` to verify the merged configuration.
+Use `make down` to stop the stack. The root `docker-compose.yml` extends the individual service files, and you can run `docker compose config` to verify the merged configuration.


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude .env files and common artifacts
- create a `Makefile` with helper commands to initialize and manage the stack
- update README with instructions on using the Makefile

## Testing
- `make config` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68509c50e92083279c60376940b48a30