### PR TITLE
Add automatic cert generation to Make up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 SERVICES=Iris Shuffle misp suricata-zeek wazuh-docker-main
 
-.PHONY: init up down config
+.PHONY: init up down config generate-indexer-certs
 
 init:
 	@for d in $(SERVICES); do \
 		cp $$d/.env.example $$d/.env; \
 	done
 
-up:
+up: generate-indexer-certs
 	docker compose up -d
 
 down:
@@ -15,3 +15,8 @@ down:
 
 config:
 	docker compose config
+
+# Generate certificates for Wazuh Indexer
+generate-indexer-certs:
+	docker compose -f wazuh-docker-main/generate-indexer-certs.yml run --rm generator
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can now orchestrate everything from the repository root. The provided Makefi
 
 ```bash
 make init   # copy every .env.example to .env
-make up     # start all containers
+make up     # start all containers (generates Wazuh SSL certs)
 ```
 
 Use `make down` to stop the stack. The root `docker-compose.yml` extends the individual service files, and you can run `docker compose config` to verify the merged configuration.


### PR DESCRIPTION
## Summary
- trigger Wazuh certificate generation from `make up`
- document the automatic step in the README

## Testing
- `make config` *(fails: docker not found)*
- `make up` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509ee7ea248327b86a721a06ff1d0d