### PR TITLE
Improve documentation for all services

### DIFF
--- a/Iris/README.md
+++ b/Iris/README.md
@@ -1,7 +1,15 @@
 # Iris
 
-Copy `.env.example` to `.env` before running `docker compose`:
+Iris is an incident response platform. The compose file in this directory starts the web application, the worker, the database and an Nginx frontend.
+
+1. Copy the example environment file:
 
 ```bash
 cp .env.example .env
+```
+
+2. Launch the service:
+
+```bash
+docker compose up -d
 ```

--- a/README.md
+++ b/README.md
@@ -1,19 +1,33 @@
 # Projet
 
-This repository contains Docker compose environments for multiple services. Each service directory includes a `docker-compose.yml` file and a `.env.example` that you should copy to `.env` before deploying with Docker Compose.
+This repository gathers several Docker Compose configurations that together form a small security lab. Each service lives in its own directory with a `docker-compose.yml` file and a `.env.example` to configure the environment.
 
-## Available services
-- Iris
-- Shuffle
-- misp
-- suricata-zeek
-- wazuh-docker-main
+## Prerequisites
 
-You can now orchestrate everything from the repository root. The provided Makefile automates the setup:
+- Docker and the Docker Compose v2 plugin installed
+- Clone this repository and copy each `.env.example` to `.env`:
 
 ```bash
-make init   # copy every .env.example to .env
-make up     # start all containers (generates Wazuh SSL certs)
+make init
 ```
 
-Use `make down` to stop the stack. The root `docker-compose.yml` extends the individual service files, and you can run `docker compose config` to verify the merged configuration.
+## Running the full stack
+
+The provided `Makefile` lets you start or stop every container at once:
+
+```bash
+make up       # start all containers and generate Wazuh certificates
+make down     # stop and remove containers
+```
+
+You can inspect the resulting configuration with `make config`.
+
+## Service overview
+
+- **Iris** – incident response platform ([Iris/README.md](Iris/README.md))
+- **Shuffle** – automation engine ([Shuffle/README.md](Shuffle/README.md))
+- **MISP** – threat intelligence sharing ([misp/README.md](misp/README.md))
+- **suricata-zeek** – network IDS sensors ([suricata-zeek/README.md](suricata-zeek/README.md))
+- **wazuh-docker-main** – SIEM stack ([wazuh-docker-main/README.md](wazuh-docker-main/README.md))
+
+The root `docker-compose.yml` extends the compose files found in each directory so everything can be orchestrated together.

--- a/Shuffle/README.md
+++ b/Shuffle/README.md
@@ -1,7 +1,15 @@
 # Shuffle
 
-Copy `.env.example` to `.env` before running `docker compose`:
+Shuffle provides workflow automation for security operations.
+
+1. Prepare the environment:
 
 ```bash
 cp .env.example .env
+```
+
+2. Start the containers:
+
+```bash
+docker compose up -d
 ```

--- a/misp/README.md
+++ b/misp/README.md
@@ -1,7 +1,15 @@
 # MISP
 
-Copy `.env.example` to `.env` before running `docker compose`:
+This directory contains a Docker Compose deployment of MISP, the threat intelligence sharing platform.
+
+1. Copy the environment file:
 
 ```bash
 cp .env.example .env
+```
+
+2. Launch MISP:
+
+```bash
+docker compose up -d
 ```

--- a/suricata-zeek/README.md
+++ b/suricata-zeek/README.md
@@ -1,7 +1,15 @@
 # Suricata and Zeek Sensors
 
-Copy `.env.example` to `.env` before running `docker compose`:
+This compose file starts Suricata and Zeek network sensors along with a Filebeat shipper.
+
+1. Copy the environment file:
 
 ```bash
 cp .env.example .env
+```
+
+2. Start the sensors:
+
+```bash
+docker compose up -d
 ```

--- a/wazuh-docker-main/README.md
+++ b/wazuh-docker-main/README.md
@@ -1,30 +1,28 @@
 # Deploy Wazuh Docker in single node configuration
 
-This deployment is defined in the `docker-compose.yml` file with one Wazuh manager container, one Wazuh indexer container, and one Wazuh dashboard container.
+This directory bundles the official Wazuh containers into a minimal SIEM stack composed of a manager, an indexer and a dashboard.
 
 Copy `.env.example` to `.env` in this directory before starting the stack.
 
 It can be deployed by following these steps:
 
-1) Increase max_map_count on your host (Linux). This command must be run with root permissions:
+1) Increase `max_map_count` on your host (Linux). This command must be run with root permissions:
+```bash
+sysctl -w vm.max_map_count=262144
 ```
-$ sysctl -w vm.max_map_count=262144
-```
-2) Generate the certificates using the provided image. Add the `HTTP_PROXY`
-   variable to `generate-indexer-certs.yml` if your environment requires a
-   proxy and run the following command:
-```
-$ docker compose -f generate-indexer-certs.yml run --rm generator
+2) Generate the certificates using the provided image. Add the `HTTP_PROXY` variable to `generate-indexer-certs.yml` if your environment requires a proxy and run:
+```bash
+docker compose -f generate-indexer-certs.yml run --rm generator
 ```
 3) Start the environment with docker compose:
 
-- In the foregroud:
-```
-$ docker compose up
+- In the foreground:
+```bash
+docker compose up
 ```
 - In the background:
-```
-$ docker compose up -d
+```bash
+docker compose up -d
 ```
 
-The environment takes about 1 minute to get up (depending on your Docker host) for the first time since Wazuh Indexer must be started for the first time and the indexes and index patterns must be generated.
+The environment takes about 1 minute to get up for the first time since Wazuh Indexer must initialize its data.


### PR DESCRIPTION
## Summary
- expand root README with prerequisites and service overview
- describe usage for each subservice README

## Testing
- `make config` *(fails: `docker: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6850a06197e48327a5258b9223be9f64