### PR TITLE
Adjust cert generation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ SERVICES=Iris Shuffle misp suricata-zeek wazuh-docker-main
 
 .PHONY: init up down config generate-indexer-certs
 
-init:
+init: generate-indexer-certs
 	@for d in $(SERVICES); do \
 		cp $$d/.env.example $$d/.env; \
 	done
 
-up: generate-indexer-certs
+up:
 	docker compose up -d
 
 down:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository gathers several Docker Compose configurations that together form
 ## Prerequisites
 
 - Docker and the Docker Compose v2 plugin installed
-- Clone this repository and copy each `.env.example` to `.env`:
+- Clone this repository and run the initialization step which copies each `.env.example` to `.env` and generates the Wazuh certificates:
 
 ```bash
 make init
@@ -16,7 +16,7 @@ make init
 The provided `Makefile` lets you start or stop every container at once:
 
 ```bash
-make up       # start all containers and generate Wazuh certificates
+make up       # start all containers
 make down     # stop and remove containers
 ```
 

--- a/wazuh-docker-main/README.md
+++ b/wazuh-docker-main/README.md
@@ -10,7 +10,7 @@ It can be deployed by following these steps:
 ```bash
 sysctl -w vm.max_map_count=262144
 ```
-2) Generate the certificates using the provided image. Add the `HTTP_PROXY` variable to `generate-indexer-certs.yml` if your environment requires a proxy and run:
+2) Generate the certificates using the provided image. This step is automatically executed when running `make init` from the repository root. If your environment requires a proxy, add the `HTTP_PROXY` variable to `generate-indexer-certs.yml` and run manually:
 ```bash
 docker compose -f generate-indexer-certs.yml run --rm generator
 ```


### PR DESCRIPTION
## Summary
- run Wazuh certificate generation during `make init`
- keep `make up` for starting containers only
- update README docs to reflect the new initialization step
- clarify certificate generation in `wazuh-docker-main` README

## Testing
- `make config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a361292c832797560bc588be2590