### PR TITLE
Fix Shuffle volume path error

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ You can inspect the resulting configuration with `make config`.
 - **wazuh-docker-main** – SIEM stack ([wazuh-docker-main/README.md](wazuh-docker-main/README.md))
 
 The root `docker-compose.yml` extends the compose files found in each directory so everything can be orchestrated together.
+
+## Data persistence
+
+Persistent volumes are stored under the top-level `volumes` directory. Create it before starting the stack:
+
+```bash
+mkdir -p volumes/shuffle-database
+```

--- a/Shuffle/.env.example
+++ b/Shuffle/.env.example
@@ -44,7 +44,7 @@ AUTH_FOR_ORBORUS=
 
 # CHANGE THIS IF YOU WANT GOOD LOCAL EXECUTIONS:
 OUTER_HOSTNAME=shuffle-backend
-DB_LOCATION=./shuffle-database
+DB_LOCATION=../volumes/shuffle-database
 DOCKER_API_VERSION=1.40
 
 # Orborus/Proxy configurations  

--- a/Shuffle/README.md
+++ b/Shuffle/README.md
@@ -6,6 +6,7 @@ Shuffle provides workflow automation for security operations.
 
 ```bash
 cp .env.example .env
+mkdir -p ../volumes/shuffle-database
 ```
 
 2. Start the containers:


### PR DESCRIPTION
## Summary
- instruct Shuffle users to store data under a shared `volumes/` folder

## Testing
- `make config` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851220fa78883278881f225cfd11bb5