### PR TITLE
Fix misp compose dependency names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,10 +79,6 @@ services:
         condition: service_healthy
       misp-modules:
         condition: service_healthy
-    environment:
-      REDIS_SERVICE: misp-redis
-      DB_SERVICE: misp-db
-      MISP_MODULES_SERVICE: misp-modules
   misp-modules:
     extends:
       file: misp/docker-compose.yml

--- a/misp/docker-compose.yml
+++ b/misp/docker-compose.yml
@@ -81,11 +81,11 @@ services:
           - PYPI_SETUPTOOLS=${PYPI_SETUPTOOLS}
           - PYPI_SUPERVISOR=${PYPI_SUPERVISOR}
     depends_on:
-      ${REDIS_SERVICE:-redis}:
+      redis:
         condition: service_healthy
-      ${DB_SERVICE:-db}:
+      db:
         condition: service_healthy
-      ${MISP_MODULES_SERVICE:-misp-modules}:
+      misp-modules:
         condition: service_healthy
     healthcheck:
       test: curl -ks ${BASE_URL:-https://localhost}/users/heartbeat > /dev/null || exit 1


### PR DESCRIPTION
## Summary
- remove unused service mapping variables from main compose
- restore static dependency names for MISP services

## Testing
- `make config` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_685158fa42d88327a5fec5a031b89be7