### PR TITLE
Fix iris docker compose extends dependency

### DIFF
--- a/Iris/docker-compose.base.yml
+++ b/Iris/docker-compose.base.yml
@@ -87,7 +87,6 @@ services:
     depends_on:
       - "rabbitmq"
       - "db"
-      - "app"
     env_file:
       - .env
     environment:
@@ -123,8 +122,7 @@ services:
     volumes:
       - "./certificates/web_certificates/:/www/certs/:ro"
     restart: always
-    depends_on:
-      - "app"
+    depends_on: []
 
 volumes:
   iris-downloads:


### PR DESCRIPTION
## Summary
- resolve invalid compose project error by removing unused `app` dependency

## Testing
- `docker compose config` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515b022884832797282ae55ae8ec38