### PR TITLE
Fix Shuffle frontend dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,8 @@ services:
       file: Shuffle/docker-compose.yml
       service: frontend
     depends_on:
-      - shuffle-backend
-  shuffle-backend:
+      - backend
+  backend:
     extends:
       file: Shuffle/docker-compose.yml
       service: backend


### PR DESCRIPTION
## Summary
- rename shuffle-backend service to backend so Shuffle frontend dependency resolves

## Testing
- `make init` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515bc0f33c8327b2588419a048e940