### PR TITLE
Fix Wazuh service dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,20 +98,20 @@ services:
       file: suricata-zeek/docker-compose.yml
       service: filebeat
 
-  wazuh-manager:
+  wazuh.manager:
     extends:
       file: wazuh-docker-main/docker-compose.yml
       service: wazuh.manager
-  wazuh-indexer:
+  wazuh.indexer:
     extends:
       file: wazuh-docker-main/docker-compose.yml
       service: wazuh.indexer
-  wazuh-dashboard:
+  wazuh.dashboard:
     extends:
       file: wazuh-docker-main/docker-compose.yml
       service: wazuh.dashboard
     depends_on:
-      wazuh-indexer:
+      wazuh.indexer:
         condition: service_started
 
 volumes:


### PR DESCRIPTION
## Summary
- fix the wazuh service names so `wazuh.dashboard` can find its dependencies

## Testing
- `make config` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515c9913bc83278e168dd2b7a0da35