### PR TITLE
Fix misp service dependency names in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,15 +57,15 @@ services:
       file: Shuffle/docker-compose.yml
       service: opensearch
 
-  misp-mail:
+  mail:
     extends:
       file: misp/docker-compose.yml
       service: mail
-  misp-redis:
+  redis:
     extends:
       file: misp/docker-compose.yml
       service: redis
-  misp-db:
+  db:
     extends:
       file: misp/docker-compose.yml
       service: db
@@ -74,9 +74,9 @@ services:
       file: misp/docker-compose.yml
       service: misp-core
     depends_on:
-      misp-redis:
+      redis:
         condition: service_healthy
-      misp-db:
+      db:
         condition: service_healthy
       misp-modules:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- fix the dependency names for misp services in docker-compose.yml

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68515d3afb2c8327988ba249b5e3ebdc