### PR TITLE
Fix iris compose dependency issue

### DIFF
--- a/Iris/docker-compose.base.yml
+++ b/Iris/docker-compose.base.yml
@@ -48,9 +48,6 @@ services:
       - user_templates:/home/iris/user_templates
       - server_data:/home/iris/server_data
     restart: always
-    depends_on:
-      - "rabbitmq"
-      - "db"
     env_file:
       - .env
     environment:
@@ -84,9 +81,6 @@ services:
       - iris-downloads:/home/iris/downloads
       - user_templates:/home/iris/user_templates
       - server_data:/home/iris/server_data
-    depends_on:
-      - "rabbitmq"
-      - "db"
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## Summary
- remove default dependencies from `Iris/docker-compose.base.yml`

This prevents `docker compose` from looking for non-existent services such as `rabbitmq` when building the project.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68515dfaad5883279dcc80b328cf665d