### PR TITLE
Add initialization script and extend documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Global environment variables for the security lab
+HTTP_PROXY=
+HTTPS_PROXY=
+TZ=UTC

--- a/Iris/README.md
+++ b/Iris/README.md
@@ -1,15 +1,21 @@
 # Iris
 
-Iris is an incident response platform. The compose file in this directory starts the web application, the worker, the database and an Nginx frontend.
+Iris is an incident response platform. The compose file in this directory starts
+the web application, the worker, the database and an Nginx frontend. The web
+interface is exposed on port **8444** by default.
+
+Documentation: <https://github.com/dfir-iris/iris-web>
 
 1. Copy the example environment file:
 
 ```bash
 cp .env.example .env
 ```
+Edit `.env` to adjust database credentials or change the exposed port if needed.
 
 2. Launch the service:
 
 ```bash
 docker compose up -d
 ```
+The web interface will then be available on [https://localhost:8444](https://localhost:8444).

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 SERVICES=Iris Shuffle misp suricata-zeek wazuh-docker-main
 
+
 .PHONY: init up down config generate-indexer-certs
 
-init: generate-indexer-certs
-	@for d in $(SERVICES); do \
-		cp $$d/.env.example $$d/.env; \
-	done
+init:
+	./scripts/init.sh
 
 up:
 	docker compose up -d

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This repository gathers several Docker Compose configurations that together form
 ## Prerequisites
 
 - Docker and the Docker Compose v2 plugin installed
-- Clone this repository and run the initialization step which copies each `.env.example` to `.env` and generates the Wazuh certificates:
+- Clone this repository and run the initialization script which prepares every
+  environment file (including the global `.env`), creates required directories
+  and generates Wazuh certificates:
 
 ```bash
 make init
@@ -24,17 +26,22 @@ You can inspect the resulting configuration with `make config`.
 
 ## Service overview
 
-- **Iris** – incident response platform ([Iris/README.md](Iris/README.md))
-- **Shuffle** – automation engine ([Shuffle/README.md](Shuffle/README.md))
-- **MISP** – threat intelligence sharing ([misp/README.md](misp/README.md))
-- **suricata-zeek** – network IDS sensors ([suricata-zeek/README.md](suricata-zeek/README.md))
-- **wazuh-docker-main** – SIEM stack ([wazuh-docker-main/README.md](wazuh-docker-main/README.md))
+| Service | Role | Ports (default) | Start command |
+|---------|------|----------------|---------------|
+| [Iris](Iris/README.md) | Incident response platform | 8444/tcp | `docker compose -f Iris/docker-compose.yml up -d` |
+| [Shuffle](Shuffle/README.md) | Automation engine | 3001/tcp, 3443/tcp, 5001/tcp, 9220/tcp | `docker compose -f Shuffle/docker-compose.yml up -d` |
+| [MISP](misp/README.md) | Threat intelligence sharing | 8080/tcp, 8445/tcp | `docker compose -f misp/docker-compose.yml up -d` |
+| [suricata-zeek](suricata-zeek/README.md) | Network IDS sensors | host network | `docker compose -f suricata-zeek/docker-compose.yml up -d` |
+| [wazuh-docker-main](wazuh-docker-main/README.md) | SIEM stack | 1514/tcp, 1515/tcp, 514/udp, 55000/tcp, 9200/tcp, 8443/tcp | `docker compose -f wazuh-docker-main/docker-compose.yml up -d` |
 
-The root `docker-compose.yml` extends the compose files found in each directory so everything can be orchestrated together.
+The root `docker-compose.yml` extends the compose files found in each directory
+so everything can be orchestrated together.
 
 ## Data persistence
 
-Persistent volumes are stored under the top-level `volumes` directory. Create it before starting the stack:
+Persistent data for some services is stored under the top-level `volumes` directory.
+The initialization script creates the required folders automatically, but you can
+also create them manually:
 
 ```bash
 mkdir -p volumes/shuffle-database

--- a/Shuffle/README.md
+++ b/Shuffle/README.md
@@ -1,6 +1,10 @@
 # Shuffle
 
-Shuffle provides workflow automation for security operations.
+Shuffle provides workflow automation for security operations. The web interface
+is reachable on port **3001** (HTTP) or **3443** (HTTPS) and the backend listens
+on **5001**. It stores its data in `../volumes/shuffle-database` by default.
+
+Documentation: <https://github.com/frikky/shuffle>
 
 1. Prepare the environment:
 
@@ -8,9 +12,12 @@ Shuffle provides workflow automation for security operations.
 cp .env.example .env
 mkdir -p ../volumes/shuffle-database
 ```
+You can edit `.env` to change default ports or proxy settings.
 
 2. Start the containers:
 
 ```bash
 docker compose up -d
 ```
+You can then browse to [http://localhost:3001](http://localhost:3001)
+or [https://localhost:3443](https://localhost:3443).

--- a/misp/README.md
+++ b/misp/README.md
@@ -1,15 +1,19 @@
 # MISP
 
-This directory contains a Docker Compose deployment of MISP, the threat intelligence sharing platform.
+This directory contains a Docker Compose deployment of MISP, the threat intelligence sharing platform. The web interface is exposed on ports **8080** (HTTP) and **8445** (HTTPS).
+
+Documentation: <https://www.misp-project.org/>
 
 1. Copy the environment file:
 
 ```bash
 cp .env.example .env
 ```
+Adjust values in `.env` such as the `ADMIN_EMAIL` or database credentials if needed.
 
 2. Launch MISP:
 
 ```bash
 docker compose up -d
 ```
+MISP should then be reachable at [https://localhost:8445](https://localhost:8445).

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Initialize environment files and volumes for the security lab
+set -euo pipefail
+
+SERVICES=(Iris Shuffle misp suricata-zeek wazuh-docker-main)
+
+# Copy global environment file
+if [ -f .env.example ] && [ ! -f .env ]; then
+  cp .env.example .env
+  echo "Created .env"
+fi
+
+for svc in "${SERVICES[@]}"; do
+  example="$svc/.env.example"
+  target="$svc/.env"
+  if [ -f "$example" ] && [ ! -f "$target" ]; then
+    cp "$example" "$target"
+    echo "Created $target"
+  fi
+done
+
+# Ensure persistent directories exist
+mkdir -p volumes/shuffle-database
+
+# Generate Wazuh Indexer certificates if missing
+cert_dir="wazuh-docker-main/config/wazuh_indexer_ssl_certs"
+if [ ! -d "$cert_dir" ] || [ -z "$(ls -A "$cert_dir" 2>/dev/null)" ]; then
+  mkdir -p "$cert_dir"
+  docker compose -f wazuh-docker-main/generate-indexer-certs.yml run --rm generator
+fi

--- a/suricata-zeek/README.md
+++ b/suricata-zeek/README.md
@@ -1,15 +1,24 @@
 # Suricata and Zeek Sensors
 
-This compose file starts Suricata and Zeek network sensors along with a Filebeat shipper.
+This compose file starts Suricata and Zeek network sensors along with a Filebeat
+shipper. Containers run in host network mode so they can monitor the interface
+specified in the `IFACE` variable (default `eth0`).
+
+Suricata: <https://suricata.io/>
+
+Zeek: <https://zeek.org/>
 
 1. Copy the environment file:
 
 ```bash
 cp .env.example .env
 ```
+Edit `.env` to set the interface name and credentials for your Wazuh Indexer.
 
 2. Start the sensors:
 
 ```bash
 docker compose up -d
 ```
+Logs are forwarded to the Wazuh stack and stored under the `zeek-logs` and
+`suricata-logs` volumes.

--- a/wazuh-docker-main/README.md
+++ b/wazuh-docker-main/README.md
@@ -2,7 +2,11 @@
 
 This directory bundles the official Wazuh containers into a minimal SIEM stack composed of a manager, an indexer and a dashboard.
 
+The dashboard is exposed on port **8443**. Consult the official documentation
+for more details: <https://documentation.wazuh.com/>
+
 Copy `.env.example` to `.env` in this directory before starting the stack.
+You may tweak this file to change passwords or exposed ports.
 
 It can be deployed by following these steps:
 


### PR DESCRIPTION
## Summary
- add global `.env.example` and initialization script
- use the new script in `make init`
- document per-service ports and usage
- provide a service table in `README.md`

## Testing
- `make config` *(fails: `docker` not found)*
- `bash scripts/init.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516113d470832789f049a858823684